### PR TITLE
Stop jukebox onunload

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,6 +39,7 @@ const logoutRouter = require(__dirname + '/routes/logout');
 const selectPlaylistRouter = require(__dirname + '/routes/select-playlist');
 const jukeboxRouter = require(__dirname + '/routes/jukebox');
 const addTrackRouter = require(__dirname + '/routes/add-track');
+const endJukeboxRouter = require(__dirname + '/routes/end-jukebox');
 
 // use routes
 app.use('/', indexRouter);
@@ -47,6 +48,7 @@ app.use('/', logoutRouter);
 app.use('/', selectPlaylistRouter);
 app.use('/', jukeboxRouter);
 app.use('/', addTrackRouter);
+app.use('/', endJukeboxRouter);
 
 // set port where app listens
 app.listen(8000);

--- a/public/js/jukebox.js
+++ b/public/js/jukebox.js
@@ -14,5 +14,18 @@ if($('#jukebox').length > 0) {
 	reloadIframe();
 
 	$('#origin').text(window.location.origin);
-	console.log(window.location.origin);
+	//console.log(window.location.origin);
+
+	// before the user closes /jukebox (by closing tab, browser, reload or back-button)
+	$(window).on('beforeunload', () => {
+		// end this jukebox so remote can't endlessly add tracks to your spotify playlist
+		$.get( "/end-jukebox");
+		// chrome doesn't shows this, but their default 'are you sure'-confirm box
+		return 'Your jukebox will be ended when you leave this page.';
+	});
+
+	// needs to be on, for confirm-box to show
+	$(window).on("unload", (event) => {
+
+	});
 };

--- a/routes/add-track.js
+++ b/routes/add-track.js
@@ -40,7 +40,7 @@ router.route('/add-track/:user_id')
 			}
 		})
 		.then( (user) => {
-			if(user) {
+			if(user && user.jukebox_playlistid) {
 				// give user.spotify_id (spotify_id) to getValidToken function, to check if access token is still valid
 				// because if it's not we can't get the playlists for this user, without refreshing it				
 				spotifyAccessToken.getValidToken(user.spotify_id)
@@ -62,7 +62,7 @@ router.route('/add-track/:user_id')
 							// if success
 							if (!error && response.statusCode === 201) {
 								// send to public/add-track.js
-								res.send({message: 'Track added'});
+								res.send({message: 'Track added, your track will appear in the jukebox shortly'});
 							} else {
 								res.send({message: 'Oops try again', error: error, responsestatusCode: response.statusCode});
 							}

--- a/routes/add-track.js
+++ b/routes/add-track.js
@@ -40,6 +40,7 @@ router.route('/add-track/:user_id')
 			}
 		})
 		.then( (user) => {
+			// if the user exists AND the playlist still exists
 			if(user && user.jukebox_playlistid) {
 				// give user.spotify_id (spotify_id) to getValidToken function, to check if access token is still valid
 				// because if it's not we can't get the playlists for this user, without refreshing it				

--- a/routes/end-jukebox.js
+++ b/routes/end-jukebox.js
@@ -11,16 +11,17 @@ router.route('/end-jukebox')
 
 			if(user){
 				db.User.update({
-					// update user add jukebox_playlistid sent from jukebox.pug
+					// remove playlistid so remote can't endlessly keep adding tracks when you close your jukebox
 					jukebox_playlistid: null
 				}, {
 					where: {
 						spotify_id: user
 					}
-				}
-				);
+				});
+				// redirects to your user profile where you can start a jukebox again
 				res.redirect('/');
 			} else {
+				// redirects to root and lets you login
 				res.redirect('/');
 			}
 	});

--- a/routes/end-jukebox.js
+++ b/routes/end-jukebox.js
@@ -5,26 +5,21 @@ const router = express.Router();
 // require database.js module
 const db = require(__dirname + '/../modules/database');
 
-router.route('/logout')
+router.route('/end-jukebox')
 	.get((req, res) => {
 			let user = req.session.user;
 
 			if(user){
-				db.User.destroy({
+				db.User.update({
+					// update user add jukebox_playlistid sent from jukebox.pug
+					jukebox_playlistid: null
+				}, {
 					where: {
-						spotify_id: req.session.user
+						spotify_id: user
 					}
-				})
-				.then( () => {
-					req.session.destroy( (err) => {
-						if(err) {
-							throw err;
-						}
-						console.log('logged out via unload')
-						// redirect to log in page and show message
-						res.redirect('/?message=' + encodeURIComponent("Successfully ended jukebox!"));
-					})
-				})
+				}
+				);
+				res.redirect('/');
 			} else {
 				res.redirect('/');
 			}

--- a/routes/jukebox.js
+++ b/routes/jukebox.js
@@ -16,8 +16,13 @@ router.route('/jukebox')
 						spotify_id: user
 					}
 				}).then((user) => {
-					// render jukebox.pug and send url of selected playlist
-					res.render('jukebox', {user_id: user.spotify_id, jukebox_url: `https://embed.spotify.com/?uri=spotify:user:${user.spotify_id}:playlist:${user.jukebox_playlistid}`});
+					// if there is a playlist chosen, otherwise redirect to '/' to choose one
+					if(user.jukebox_playlistid) {
+						// render jukebox.pug and send url of selected playlist
+						res.render('jukebox', {user_id: user.spotify_id, user_name: user.display_name, jukebox_url: `https://embed.spotify.com/?uri=spotify:user:${user.spotify_id}:playlist:${user.jukebox_playlistid}`});
+					} else {
+						res.redirect('/');
+					}
 				})
 		} else {
 			res.redirect('/');

--- a/views/jukebox.pug
+++ b/views/jukebox.pug
@@ -4,6 +4,8 @@ html
 	body#jukebox
 		div.container
 			div
+				div#owner-jukebox
+					h2 Welcome to the jukebox of #{user_name}
 				div#player
 					iframe(src="" + jukebox_url width="1000" height="300" frameborder="0" allowtransparency="true"
 					id="spotify_player")
@@ -16,7 +18,7 @@ html
 					a.btn.btn-primary(href="/logout") End jukebox
 				div#remote-url
 					h2 Put another dime in the jukebox, baby
-					h4 Follow this link on you device to add a track to this jukebox
+					h4 Follow this link on your device to add a track to this jukebox
 					a(href="/add-track/" + user_id target="_blank") 
 						span#origin 
 						span /add-track/#{user_id}

--- a/views/jukebox.pug
+++ b/views/jukebox.pug
@@ -17,7 +17,7 @@ html
 				div#remote-url
 					h2 Put another dime in the jukebox, baby
 					h4 Follow this link on you device to add a track to this jukebox
-					a(href="/add-track/" + user_id) 
+					a(href="/add-track/" + user_id target="_blank") 
 						span#origin 
 						span /add-track/#{user_id}
 

--- a/views/remote.pug
+++ b/views/remote.pug
@@ -3,6 +3,8 @@ html
 
 	body#remote
 		div.container
+			div#owner-jukebox
+				h2 Welcome to the jukebox of #{user_name}
 			div#search-and-add
 				h2 Add track to jukebox
 				//- search bar

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,7 @@ const config = {
 	},
 	// transpile css to support last 2 versions of all browsers.
 	postcss: [
-		autoprefixer( { browsers: ['last 2 versions'] } );
+		autoprefixer( { browsers: ['last 2 versions'] } )
 	]
 
 }


### PR DESCRIPTION
Remove playlist id from database, when user unloads the jukebox, so remote can't endlessy keeps adding tracks to playlist of user

When remote is adding tracks and playlist is removed in the meantime, it redirects to login with message that this jukebox is no more and they can start their own

When the user goes to /jukebox directly but didn't add a playlist it redirects to '/' where they choose a playlist